### PR TITLE
[htc] do not use gzip decompression

### DIFF
--- a/hand_tracking_toolkit/evaluation.py
+++ b/hand_tracking_toolkit/evaluation.py
@@ -47,9 +47,9 @@ def extract_tar(tar_file: Path, extract_dir: Path) -> None:
         raise RuntimeError("Incorrect tar file format")
 
     print(f"Untaring {tar_file}")
-    tf = tarfile.open(tar_file, mode)
-    tf.extractall(extract_dir)
-    tf.close()
+    with tarfile.open(tar_file, mode) as tf:
+        print(f"Opened tar file")
+        tf.extractall(extract_dir)
     print(f"Finished untaring {tar_file}")
 
 

--- a/hand_tracking_toolkit/evaluation.py
+++ b/hand_tracking_toolkit/evaluation.py
@@ -211,7 +211,7 @@ def evaluate_shape_dataset(
     return shape_metrics
 
 
-def evaluate(test_annotation_file, user_submission_file, phase_codename):
+def evaluate(test_annotation_file, user_submission_file, phase_codename, **kwargs):
     print("Starting Evaluation.....")
     """
     Evaluates the submission for a particular challenge phase and returns score
@@ -246,7 +246,7 @@ def evaluate(test_annotation_file, user_submission_file, phase_codename):
             'submitted_at': u'2017-03-20T19:22:03.880652Z'
         }
     """
-    print(f"Evaluating {phase_codename} branch:linguang")
+    print(f"Evaluating {phase_codename}")
     output = []
     with tempfile.TemporaryDirectory() as tmp_dir:
         gt_dir = Path(tmp_dir, "gt")

--- a/hand_tracking_toolkit/evaluation.py
+++ b/hand_tracking_toolkit/evaluation.py
@@ -35,18 +35,18 @@ from .hand_models.mano_hand_model import MANOHandModel
 from .metrics import compute_pose_metrics, compute_shape_metrics
 
 
-def extract_tar(tar_file: Path, extract_dir: Path) -> None:
+def extract_tar(tar_file: Path, extract_dir: Path, mode: Optional[str] = None) -> None:
     assert tar_file.exists()
 
-    # if tar_file.suffix == ".tar":
-    #     mode = "r"
-    # elif tar_file.suffix == ".gz":
-    #     mode = "r:gz"
-    # elif tar_file.suffix == ".tgz":
-    #     mode = "r:gz"
-    # else:
-    #     raise RuntimeError("Incorrect tar file format")
-    mode = "r"
+    if mode is None:
+        if tar_file.suffix == ".tar":
+            mode = "r"
+        elif tar_file.suffix == ".gz":
+            mode = "r:gz"
+        elif tar_file.suffix == ".tgz":
+            mode = "r:gz"
+        else:
+            raise RuntimeError("Incorrect tar file format")
 
     print(f"Untaring {tar_file}: {os.path.getsize(tar_file)}")
     with tarfile.open(tar_file, mode) as tf:
@@ -222,7 +222,7 @@ def evaluate_shape_dataset(
     return shape_metrics
 
 
-def evaluate(test_annotation_file, user_submission_file, phase_codename, **kwargs):
+def evaluate_impl(test_annotation_file, user_submission_file, phase_codename, mode):
     print("Starting Evaluation.....")
     """
     Evaluates the submission for a particular challenge phase and returns score
@@ -262,8 +262,8 @@ def evaluate(test_annotation_file, user_submission_file, phase_codename, **kwarg
     with tempfile.TemporaryDirectory() as tmp_dir:
         gt_dir = Path(tmp_dir, "gt")
         pred_dir = Path(tmp_dir, "pred")
-        extract_tar(Path(user_submission_file), pred_dir)
-        extract_tar(Path(test_annotation_file), gt_dir)
+        extract_tar(Path(user_submission_file), pred_dir, mode)
+        extract_tar(Path(test_annotation_file), gt_dir, mode)
         mano_model = MANOHandModel(str(gt_dir.joinpath("mano")))
         print("Down building mano model")
 
@@ -286,3 +286,8 @@ def evaluate(test_annotation_file, user_submission_file, phase_codename, **kwarg
         print(f"Completed evaluation for {phase_codename}")
 
     return {"result": output}
+
+def evaluate(test_annotation_file, user_submission_file, phase_codename, **kwargs):
+    # evalAI automatically decompresses gzip files. Do not decompress again.
+    # Treat the file as an uncompressed tar file.
+    evaluate_impl(test_annotation_file, user_submission_file, phase_codename, mode="r")

--- a/hand_tracking_toolkit/evaluation.py
+++ b/hand_tracking_toolkit/evaluation.py
@@ -46,9 +46,11 @@ def extract_tar(tar_file: Path, extract_dir: Path) -> None:
     else:
         raise RuntimeError("Incorrect tar file format")
 
+    print(f"Untaring {tar_file}")
     tf = tarfile.open(tar_file, mode)
     tf.extractall(extract_dir)
     tf.close()
+    print(f"Finished untaring {tar_file}")
 
 
 def group_by_sequence_names(all_entries):
@@ -185,8 +187,10 @@ def evaluate_pose_dataset(
     pose_pred = load_pred_pose_file(pred_dir, dataset_suffix)
     if pose_pred is None:
         return None
+    print(f"Done loading pred file from {pred_dir}")
 
     landmarks_gt, shape_gt = load_gt_files(gt_dir, dataset_suffix)
+    print(f"Done loading gt file from {gt_dir}")
 
     pose_metrics = compute_overall_pose_metrics(
         sequence_name_to_pose_pred=pose_pred,
@@ -203,8 +207,10 @@ def evaluate_shape_dataset(
     shape_pred = load_pred_shape_file(pred_dir, dataset_suffix)
     if shape_pred is None:
         return None
+    print(f"Done loading pred file from {pred_dir}")
 
     _, shape_gt = load_gt_files(gt_dir, dataset_suffix)
+    print(f"Done loading gt file from {gt_dir}")
 
     shape_metrics = compute_overall_shape_metrics(
         sequence_name_to_shape_gt=shape_gt,
@@ -249,7 +255,7 @@ def evaluate(test_annotation_file, user_submission_file, phase_codename, **kwarg
             'submitted_at': u'2017-03-20T19:22:03.880652Z'
         }
     """
-    print(f"Evaluating {phase_codename}")
+    print(f"Evaluating {phase_codename} branch:linguang")
     output = []
     with tempfile.TemporaryDirectory() as tmp_dir:
         gt_dir = Path(tmp_dir, "gt")
@@ -257,6 +263,7 @@ def evaluate(test_annotation_file, user_submission_file, phase_codename, **kwarg
         extract_tar(Path(test_annotation_file), gt_dir)
         extract_tar(Path(user_submission_file), pred_dir)
         mano_model = MANOHandModel(str(gt_dir.joinpath("mano")))
+        print("Down building mano model")
 
         if phase_codename == "pose_estimation":
             for dataset_suffix in ["umetrack", "hot3d"]:

--- a/hand_tracking_toolkit/evaluation.py
+++ b/hand_tracking_toolkit/evaluation.py
@@ -38,14 +38,15 @@ from .metrics import compute_pose_metrics, compute_shape_metrics
 def extract_tar(tar_file: Path, extract_dir: Path) -> None:
     assert tar_file.exists()
 
-    if tar_file.suffix == ".tar":
-        mode = "r"
-    elif tar_file.suffix == ".gz":
-        mode = "r:gz"
-    elif tar_file.suffix == ".tgz":
-        mode = "r:gz"
-    else:
-        raise RuntimeError("Incorrect tar file format")
+    # if tar_file.suffix == ".tar":
+    #     mode = "r"
+    # elif tar_file.suffix == ".gz":
+    #     mode = "r:gz"
+    # elif tar_file.suffix == ".tgz":
+    #     mode = "r:gz"
+    # else:
+    #     raise RuntimeError("Incorrect tar file format")
+    mode = "r"
 
     print(f"Untaring {tar_file}: {os.path.getsize(tar_file)}")
     with tarfile.open(tar_file, mode) as tf:

--- a/hand_tracking_toolkit/evaluation.py
+++ b/hand_tracking_toolkit/evaluation.py
@@ -254,7 +254,7 @@ def evaluate(test_annotation_file, user_submission_file, phase_codename, **kwarg
         extract_tar(Path(user_submission_file), pred_dir)
         extract_tar(Path(test_annotation_file), gt_dir)
         mano_model = MANOHandModel(str(gt_dir.joinpath("mano")))
-        print("Down building mano model")
+        print("Done building the MANO model")
 
         if phase_codename == "pose_estimation":
             for dataset_suffix in ["umetrack", "hot3d"]:

--- a/hand_tracking_toolkit/evaluation.py
+++ b/hand_tracking_toolkit/evaluation.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
+import os
 
 from .hand_models.mano_hand_model import MANOHandModel
 
@@ -46,7 +47,7 @@ def extract_tar(tar_file: Path, extract_dir: Path) -> None:
     else:
         raise RuntimeError("Incorrect tar file format")
 
-    print(f"Untaring {tar_file}")
+    print(f"Untaring {tar_file}: {os.path.getsize(tar_file)}")
     with tarfile.open(tar_file, mode) as tf:
         print(f"Opened tar file")
         tf.extractall(extract_dir)

--- a/hand_tracking_toolkit/evaluation.py
+++ b/hand_tracking_toolkit/evaluation.py
@@ -274,4 +274,4 @@ def evaluate(test_annotation_file, user_submission_file, phase_codename, **kwarg
 
         print(f"Completed evaluation for {phase_codename}")
 
-    return {"result": output}    
+    return {"result": output}

--- a/hand_tracking_toolkit/evaluation.py
+++ b/hand_tracking_toolkit/evaluation.py
@@ -39,7 +39,7 @@ def extract_tar(tar_file: Path, extract_dir: Path) -> None:
     assert tar_file.exists()
     print(f"Untaring {tar_file}: {os.path.getsize(tar_file)}")
     with tarfile.open(tar_file, "r") as tf:
-        print(f"Opened tar file")
+        print("Opened tar file")
         tf.extractall(extract_dir)
     print(f"Finished untaring {tar_file}")
 

--- a/hand_tracking_toolkit/evaluation.py
+++ b/hand_tracking_toolkit/evaluation.py
@@ -260,8 +260,8 @@ def evaluate(test_annotation_file, user_submission_file, phase_codename, **kwarg
     with tempfile.TemporaryDirectory() as tmp_dir:
         gt_dir = Path(tmp_dir, "gt")
         pred_dir = Path(tmp_dir, "pred")
-        extract_tar(Path(test_annotation_file), gt_dir)
         extract_tar(Path(user_submission_file), pred_dir)
+        extract_tar(Path(test_annotation_file), gt_dir)
         mano_model = MANOHandModel(str(gt_dir.joinpath("mano")))
         print("Down building mano model")
 

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -36,7 +36,9 @@ def parse_args():
 def main() -> None:
     args = parse_args()
     output = evaluate(
-        args.test_annotation_file, args.user_submission_file, args.phase_codename, mode=None
+        args.test_annotation_file,
+        args.user_submission_file,
+        args.phase_codename,
     )
     print(output)
 

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -36,7 +36,7 @@ def parse_args():
 def main() -> None:
     args = parse_args()
     output = evaluate(
-        args.test_annotation_file, args.user_submission_file, args.phase_codename
+        args.test_annotation_file, args.user_submission_file, args.phase_codename, mode=None
     )
     print(output)
 


### PR DESCRIPTION
It turns out evalAI does automatic decompression, so if we specify :gz the script will fail.
It also seems that python tarfile library can handle both compressed and uncompressed tar files with a single read mode ("r")